### PR TITLE
Add state monad & Rework Monad interface

### DIFF
--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -14,10 +14,10 @@ fn startup_nuclear_reactor() -> Logging<bool> {
 
 	if core_temp < 200.0 {
 		Logging::log("Reactor core temperature is nominal")?;
-		ret(true)
+		Logging::ret(true)
 	} else {
 		Logging::log("Reactor core is too hot, abort")?;
-		ret(false)
+		Logging::ret(false)
 	}
 }
 
@@ -25,13 +25,13 @@ fn startup_nuclear_reactor() -> Logging<bool> {
 fn run_safety_checks() -> Logging<()> {
 	Logging::log("Running safety checks...")?;
 	Logging::log("All is OK")?;
-	ret(())
+	Logging::ret(())
 }
 
 #[monadic]
 fn activate_warning_lights() -> Logging<()> {
 	Logging::log("Warning lights activated")?;
-	ret(())
+	Logging::ret(())
 }
 
 #[monadic]
@@ -45,5 +45,5 @@ fn get_core_temp() -> Logging<f32> {
 			40.0 + (i as f32)
 		))?;
 	}
-	ret(core_temp_arg / 4.0)
+	Logging::ret(core_temp_arg / 4.0)
 }

--- a/examples/option.rs
+++ b/examples/option.rs
@@ -10,10 +10,10 @@ fn main() {
 
 #[monadic]
 fn aggregate_sensor_readings() -> Option<f32> {
-	ret((read_unreliable_sensor()? + read_unreliable_sensor()?) / 2.0)
+	Option::ret((read_unreliable_sensor()? + read_unreliable_sensor()?) / 2.0)
 }
 
 #[monadic]
 fn read_unreliable_sensor() -> Option<f32> {
-	ret(42.0)
+	Option::ret(42.0)
 }

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,0 +1,152 @@
+use std::{borrow::Borrow, fmt};
+
+use monads_rs::*;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Player {
+	CROSS,
+	NOUGHT,
+}
+
+impl Player {
+	fn flip(&self) -> Self {
+		if *self == Player::CROSS {
+			return Player::NOUGHT;
+		} else {
+			return Player::CROSS;
+		}
+	}
+}
+
+impl fmt::Display for Player {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Player::CROSS => write!(f, "X"),
+			Player::NOUGHT => write!(f, "O"),
+		}
+	}
+}
+
+fn disp(op: Option<Player>) -> String {
+	format!("{}", op.map_or("_".to_string(), |x| x.to_string()))
+}
+
+type Board = [Option<Player>; 9];
+
+#[derive(Clone, Copy, Debug)]
+struct GameState {
+	board: Board,
+	turn: Player,
+	round_count: usize,
+}
+
+impl GameState {
+	pub fn new() -> Self {
+		Self {
+			board: [None, None, None, None, None, None, None, None, None],
+			turn: Player::CROSS,
+			round_count: 1,
+		}
+	}
+}
+
+impl fmt::Display for GameState {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(
+			f,
+			"{}{}{}\n{}{}{}\n{}{}{}\n",
+			disp(self.board[0]),
+			disp(self.board[1]),
+			disp(self.board[2]),
+			disp(self.board[3]),
+			disp(self.board[4]),
+			disp(self.board[5]),
+			disp(self.board[6]),
+			disp(self.board[7]),
+			disp(self.board[8]),
+		)
+	}
+}
+
+#[monadic]
+fn inc_round_counter() -> State<'static, GameState, ()> {
+	let mut state = State::<'_, GameState, GameState>::get()?;
+	state.round_count += 1;
+	return State::<'_, GameState, ()>::set(state);
+}
+
+// Getters
+#[monadic]
+fn get_board() -> State<'static, GameState, Board> {
+	let state = State::<'_, GameState, GameState>::get()?;
+	State::ret(state.board)
+}
+
+#[monadic]
+fn get_current_player() -> State<'static, GameState, Player> {
+	let state = State::<'_, GameState, GameState>::get()?;
+	State::ret(state.turn)
+}
+
+#[monadic]
+fn get_turn_counter() -> State<'static, GameState, usize> {
+	let state = State::<'_, GameState, GameState>::get()?;
+	State::ret(state.round_count)
+}
+// Setters
+
+#[monadic]
+fn set_board(board: Board) -> State<'static, GameState, ()> {
+	State::<'_, GameState, GameState>::get().bind(move |mut state| {
+		state.board = board;
+		State::<'_, GameState, ()>::set(state)
+	})
+}
+
+#[monadic]
+fn switch_current_player() -> State<'static, GameState, ()> {
+	let mut state = State::<'_, GameState, GameState>::get()?;
+	state.turn = state.turn.flip();
+	State::<'_, GameState, ()>::set(state)
+}
+
+#[monadic]
+fn inc_turn_counter(board: Board) -> State<'static, GameState, ()> {
+	let mut state = State::<'_, GameState, GameState>::get()?;
+	state.round_count += 1;
+	State::<'_, GameState, ()>::set(state)
+}
+
+#[monadic]
+fn set_piece(x: usize, y: usize) -> State<'static, GameState, ()> {
+	get_board().bind(move |board| {
+		get_current_player().bind(move |player| {
+			let mut new_board = board.clone();
+			new_board[x % 3 + y * 3] = Some(player);
+			set_board(new_board)
+		})
+	})
+}
+
+#[monadic]
+fn play_turn(x: usize, y: usize) -> State<'static, GameState, ()> {
+	set_piece(x, y)?;
+	switch_current_player()?;
+	inc_round_counter()
+}
+
+#[monadic]
+fn program() -> State<'static, GameState, ()> {
+	play_turn(0, 0)?;
+	play_turn(0, 2)?;
+	play_turn(2, 0)?;
+	play_turn(1, 0)?;
+	play_turn(2, 2)?;
+	play_turn(2, 1)?;
+	play_turn(1, 1)
+}
+
+fn main() {
+	let state = program().run_state.as_ref()(GameState::new());
+	println!("{}", state.0);
+}

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, fmt};
+use std::fmt;
 
 use monads_rs::*;
 
@@ -88,11 +88,6 @@ fn get_current_player() -> State<'static, GameState, Player> {
 	State::ret(state.turn)
 }
 
-#[monadic]
-fn get_turn_counter() -> State<'static, GameState, usize> {
-	let state = State::<'_, GameState, GameState>::get()?;
-	State::ret(state.round_count)
-}
 // Setters
 
 #[monadic]
@@ -107,13 +102,6 @@ fn set_board(board: Board) -> State<'static, GameState, ()> {
 fn switch_current_player() -> State<'static, GameState, ()> {
 	let mut state = State::<'_, GameState, GameState>::get()?;
 	state.turn = state.turn.flip();
-	State::<'_, GameState, ()>::set(state)
-}
-
-#[monadic]
-fn inc_turn_counter(board: Board) -> State<'static, GameState, ()> {
-	let mut state = State::<'_, GameState, GameState>::get()?;
-	state.round_count += 1;
 	State::<'_, GameState, ()>::set(state)
 }
 
@@ -147,6 +135,6 @@ fn program() -> State<'static, GameState, ()> {
 }
 
 fn main() {
-	let state = program().run_state.as_ref()(GameState::new());
+	let state = program().run(GameState::new());
 	println!("{}", state.0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//pub mod logging;
+pub mod logging;
 mod option;
 mod result;
 mod state;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,28 @@
-pub mod logging;
-mod option;
-mod result;
+//pub mod logging;
+//mod option;
+//mod result;
+mod state;
 
 pub use monads_rs_codegen::*;
 
-pub use option::*;
-pub use result::*;
+//pub use option::*;
+//pub use result::*;
 
 /// A type is a `Functor` if it can be mapped over turning `A`s into `B`s while preserving the
 /// structure of the original type.
-pub trait Functor<A> {
-	type Map<B>: Functor<B>;
+pub trait Functor<'a,A> {
+	type Map<B>: Functor<'a,B>;
 
 	/// Maps a function `f` over each `A` element of the original type, returning a new type
 	/// with the same structure but with `B` elements.
-	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B>;
+	fn map<B, F: Fn(A) -> B>(self, f: &'static F) -> Self::Map<B>;
 }
 
 /// A `Functor` with application, providing operations to
 /// * embed "pure" expressions, and
 /// * sequence computations and combine their results.
-pub trait Applicative<A>: Functor<A> {
-	type Apply<B>: Applicative<B>;
+pub trait Applicative<'a,A>: Functor<'a, A> {
+	type Apply<B>: Applicative<'a, B>;
 
 	/// Embeds a value into the structure.
 	fn pure(a: A) -> Self;
@@ -32,8 +33,8 @@ pub trait Applicative<A>: Functor<A> {
 
 /// A `Applicative` with a monadic binding operation. Representing the idea of
 /// a monad from mathematics category theory.
-pub trait Monad<A>: Applicative<A> {
-	type Bind<B>: Monad<B>;
+pub trait Monad<'a,A>: Applicative<'a,A> {
+	type Bind<B>: Monad<'a,B>;
 
 	/// Sequentially compose two actions, passing any value produced by the
 	/// first as an argument to the second.
@@ -41,6 +42,6 @@ pub trait Monad<A>: Applicative<A> {
 }
 
 /// Embeds a "pure" expression `a` into a `Monad`.
-pub fn ret<A, M: Monad<A>>(a: A) -> M {
+pub fn ret<A, M: for<'a> Monad<'a, A>>(a: A) -> M {
 	M::pure(a)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //pub mod logging;
-//mod option;
+mod option;
 mod result;
 mod state;
 pub use monads_rs_codegen::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //pub mod logging;
 //mod option;
-//mod result;
+mod result;
 mod state;
 pub use monads_rs_codegen::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,22 +9,15 @@ pub use state::*;
 //pub use option::*;
 //pub use result::*;
 
-/// A type is a `Functor` if it can be mapped over turning `A`s into `B`s while preserving the
-/// structure of the original type.pub trait Functor<'a, A> {
-pub trait Functor<'a, A> {
-	type Target<T>;
-	fn fmap<B, F>(self, f: F) -> Self::Target<B>
-	where
-		F: Fn(A) -> B + 'a;
-}
-
-/// A `Functor` with a monadic binding operation. Representing the idea of
-/// a monad from mathematics category theory.
-pub trait Monad<'c, C>: Functor<'c, C> {
+/// A `Monad` with a monadic binding operation. Representing the idea of a
+/// monad from mathematics category theory.
+pub trait Monad<'c, C> {
 	type Bind<B>;
 
 	/// Sequentially compose two actions, passing any value produced by the
 	/// first as an argument to the second.
 	fn bind<B, F: Fn(C) -> Self::Bind<B> + 'c>(self, f: F) -> Self::Bind<B>;
+
+	/// Lift a value into the `Monad`.
 	fn ret(c: C) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,46 +2,29 @@
 //mod option;
 //mod result;
 mod state;
-
 pub use monads_rs_codegen::*;
+
+pub use state::*;
 
 //pub use option::*;
 //pub use result::*;
 
 /// A type is a `Functor` if it can be mapped over turning `A`s into `B`s while preserving the
-/// structure of the original type.
-pub trait Functor<'a,A> {
-	type Map<B>: Functor<'a,B>;
-
-	/// Maps a function `f` over each `A` element of the original type, returning a new type
-	/// with the same structure but with `B` elements.
-	fn map<B, F: Fn(A) -> B>(self, f: &'static F) -> Self::Map<B>;
+/// structure of the original type.pub trait Functor<'a, A> {
+pub trait Functor<'a, A> {
+	type Target<T>;
+	fn fmap<B, F>(self, f: F) -> Self::Target<B>
+	where
+		F: Fn(A) -> B + 'a;
 }
 
-/// A `Functor` with application, providing operations to
-/// * embed "pure" expressions, and
-/// * sequence computations and combine their results.
-pub trait Applicative<'a,A>: Functor<'a, A> {
-	type Apply<B>: Applicative<'a, B>;
-
-	/// Embeds a value into the structure.
-	fn pure(a: A) -> Self;
-
-	/// Sequences computations and combines their results.
-	fn ap<B, F: FnOnce(A) -> B>(self, f: Self::Apply<F>) -> Self::Apply<B>;
-}
-
-/// A `Applicative` with a monadic binding operation. Representing the idea of
+/// A `Functor` with a monadic binding operation. Representing the idea of
 /// a monad from mathematics category theory.
-pub trait Monad<'a,A>: Applicative<'a,A> {
-	type Bind<B>: Monad<'a,B>;
+pub trait Monad<'c, C>: Functor<'c, C> {
+	type Bind<B>;
 
 	/// Sequentially compose two actions, passing any value produced by the
 	/// first as an argument to the second.
-	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B>;
-}
-
-/// Embeds a "pure" expression `a` into a `Monad`.
-pub fn ret<A, M: for<'a> Monad<'a, A>>(a: A) -> M {
-	M::pure(a)
+	fn bind<B, F: Fn(C) -> Self::Bind<B> + 'c>(self, f: F) -> Self::Bind<B>;
+	fn ret(c: C) -> Self;
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,7 +23,7 @@ impl<A> Logging<A> {
 	}
 }
 
-impl<A> Functor<A> for Logging<A> {
+impl<'a,A> Functor<'a,A> for Logging<A> {
 	type Map<B> = Logging<B>;
 
 	/// Applies the function `f` to the value while keeping the logs intact.
@@ -35,7 +35,7 @@ impl<A> Functor<A> for Logging<A> {
 	}
 }
 
-impl<A> Applicative<A> for Logging<A> {
+impl<'a,A> Applicative<'a,A> for Logging<A> {
 	type Apply<B> = Logging<B>;
 
 	/// Creates a new `Logging` with the `value` and an empty log.
@@ -55,7 +55,7 @@ impl<A> Applicative<A> for Logging<A> {
 	}
 }
 
-impl<A> Monad<A> for Logging<A> {
+impl<'a,A> Monad<'a,A> for Logging<A> {
 	type Bind<B> = Logging<B>;
 
 	/// Applies the function `f` to the value, making sure the logs are a

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use super::{Applicative, Functor, Monad};
+use super::{Monad};
 
 /// Simple logging monad.
 pub struct Logging<A> {
@@ -23,38 +23,6 @@ impl<A> Logging<A> {
 	}
 }
 
-impl<'a,A> Functor<'a,A> for Logging<A> {
-	type Map<B> = Logging<B>;
-
-	/// Applies the function `f` to the value while keeping the logs intact.
-	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B> {
-		Logging {
-			value: f(self.value),
-			log: self.log,
-		}
-	}
-}
-
-impl<'a,A> Applicative<'a,A> for Logging<A> {
-	type Apply<B> = Logging<B>;
-
-	/// Creates a new `Logging` with the `value` and an empty log.
-	fn pure(value: A) -> Self {
-		Logging {
-			value,
-			log: Vec::new(),
-		}
-	}
-
-	/// Uses the `value` of `f` as a function for mapping the `value` of
-	/// `self`. The logs of `f` are appended to the logs of `self`.
-	fn ap<B, F: FnOnce(A) -> B>(self, mut f: Self::Apply<F>) -> Self::Apply<B> {
-		let mut next = self.map(f.value);
-		next.log.append(&mut f.log);
-		next
-	}
-}
-
 impl<'a,A> Monad<'a,A> for Logging<A> {
 	type Bind<B> = Logging<B>;
 
@@ -66,12 +34,15 @@ impl<'a,A> Monad<'a,A> for Logging<A> {
 		next.log = self.log;
 		next
 	}
+
+	fn ret(val: A) -> Self {
+		return Logging { value: val, log: vec![] }
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::ret;
 
 	/// Logs the path of the function, and returns a value.
 	fn log_function(a: bool) -> Logging<i32> {
@@ -83,12 +54,12 @@ mod tests {
 			}
 			.bind(|_| {
 				(1..4)
-					.fold(Logging::pure(()), |b, i| {
+					.fold(Logging::ret(()), |b, i| {
 						b.bind(|_| {
 							Logging::log(format!("Logging iteration: {i}"))
 						})
 					})
-					.bind(|_| ret(2))
+					.bind(|_| Logging::ret(2))
 			})
 		})
 	}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use super::{Monad};
+use super::Monad;
 
 /// Simple logging monad.
 pub struct Logging<A> {
@@ -23,7 +23,7 @@ impl<A> Logging<A> {
 	}
 }
 
-impl<'a,A> Monad<'a,A> for Logging<A> {
+impl<'a, A> Monad<'a, A> for Logging<A> {
 	type Bind<B> = Logging<B>;
 
 	/// Applies the function `f` to the value, making sure the logs are a
@@ -36,7 +36,10 @@ impl<'a,A> Monad<'a,A> for Logging<A> {
 	}
 
 	fn ret(val: A) -> Self {
-		return Logging { value: val, log: vec![] }
+		Logging {
+			value: val,
+			log: vec![],
+		}
 	}
 }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,13 +1,13 @@
-use super::{Monad};
+use super::Monad;
 
-impl<'a,A> Monad<'a,A> for Option<A> {
+impl<'a, A> Monad<'a, A> for Option<A> {
 	type Bind<B> = Option<B>;
 
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {
 		self.and_then(f)
 	}
 
-	fn ret(val : A) -> Self {
+	fn ret(val: A) -> Self {
 		Some(val)
 	}
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,6 +1,6 @@
 use super::{Applicative, Functor, Monad};
 
-impl<A> Functor<A> for Option<A> {
+impl<'a,A> Functor<'a,A> for Option<A> {
 	type Map<B> = Option<B>;
 
 	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B> {
@@ -8,7 +8,7 @@ impl<A> Functor<A> for Option<A> {
 	}
 }
 
-impl<A> Applicative<A> for Option<A> {
+impl<'a,A> Applicative<'a,A> for Option<A> {
 	type Apply<B> = Option<B>;
 
 	fn pure(a: A) -> Self {
@@ -20,7 +20,7 @@ impl<A> Applicative<A> for Option<A> {
 	}
 }
 
-impl<A> Monad<A> for Option<A> {
+impl<'a,A> Monad<'a,A> for Option<A> {
 	type Bind<B> = Option<B>;
 
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,24 +1,4 @@
-use super::{Applicative, Functor, Monad};
-
-impl<'a,A> Functor<'a,A> for Option<A> {
-	type Map<B> = Option<B>;
-
-	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B> {
-		self.map(f)
-	}
-}
-
-impl<'a,A> Applicative<'a,A> for Option<A> {
-	type Apply<B> = Option<B>;
-
-	fn pure(a: A) -> Self {
-		Some(a)
-	}
-
-	fn ap<B, F: FnOnce(A) -> B>(self, f: Self::Apply<F>) -> Self::Apply<B> {
-		self.and_then(|a| f.map(|f| f(a)))
-	}
-}
+use super::{Monad};
 
 impl<'a,A> Monad<'a,A> for Option<A> {
 	type Bind<B> = Option<B>;
@@ -26,30 +6,33 @@ impl<'a,A> Monad<'a,A> for Option<A> {
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {
 		self.and_then(f)
 	}
+
+	fn ret(val : A) -> Self {
+		Some(val)
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::ret;
 
 	#[test]
 	fn pure_test() {
-		let val: Option<i32> = ret(42);
+		let val: Option<i32> = Option::ret(42);
 		assert_eq!(val, Some(42))
 	}
 
 	#[test]
 	fn binding() {
-		let val: Option<i32> = ret(42);
-		let result = val.bind(|v| ret(v + 1));
+		let val: Option<i32> = Option::ret(42);
+		let result = val.bind(|v| Option::ret(v + 1));
 		assert_eq!(result, Some(43))
 	}
 
 	#[test]
 	fn short_curcuit() {
 		let val: Option<i32> = Option::None;
-		let result = val.bind(|v| ret(v + 1));
+		let result = val.bind(|v| Option::ret(v + 1));
 		assert_eq!(result, Option::None)
 	}
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,14 +1,14 @@
-use super::{Monad};
+use super::Monad;
 
-impl<'a,A, E> Monad<'a,A> for Result<A, E> {
+impl<'a, A, E> Monad<'a, A> for Result<A, E> {
 	type Bind<B> = Result<B, E>;
 
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {
 		self.and_then(f)
 	}
 
-	fn ret(val : A) -> Self {
-		return Ok(val);
+	fn ret(val: A) -> Self {
+		Ok(val)
 	}
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use super::{Applicative, Functor, Monad};
 
-impl<A, E> Functor<A> for Result<A, E> {
+impl<'a,A, E> Functor<'a,A> for Result<A, E> {
 	type Map<B> = Result<B, E>;
 
 	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B> {
@@ -8,7 +8,7 @@ impl<A, E> Functor<A> for Result<A, E> {
 	}
 }
 
-impl<A, E> Applicative<A> for Result<A, E> {
+impl<'a,A, E> Applicative<'a,A> for Result<A, E> {
 	type Apply<B> = Result<B, E>;
 
 	fn pure(a: A) -> Self {
@@ -20,7 +20,7 @@ impl<A, E> Applicative<A> for Result<A, E> {
 	}
 }
 
-impl<A, E> Monad<A> for Result<A, E> {
+impl<'a,A, E> Monad<'a,A> for Result<A, E> {
 	type Bind<B> = Result<B, E>;
 
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,24 +1,4 @@
-use super::{Applicative, Functor, Monad};
-
-impl<'a,A, E> Functor<'a,A> for Result<A, E> {
-	type Map<B> = Result<B, E>;
-
-	fn map<B, F: FnOnce(A) -> B>(self, f: F) -> Self::Map<B> {
-		self.map(f)
-	}
-}
-
-impl<'a,A, E> Applicative<'a,A> for Result<A, E> {
-	type Apply<B> = Result<B, E>;
-
-	fn pure(a: A) -> Self {
-		Ok(a)
-	}
-
-	fn ap<B, F: FnOnce(A) -> B>(self, f: Self::Apply<F>) -> Self::Apply<B> {
-		self.and_then(|a| f.map(|f| f(a)))
-	}
-}
+use super::{Monad};
 
 impl<'a,A, E> Monad<'a,A> for Result<A, E> {
 	type Bind<B> = Result<B, E>;
@@ -26,23 +6,26 @@ impl<'a,A, E> Monad<'a,A> for Result<A, E> {
 	fn bind<B, F: FnOnce(A) -> Self::Bind<B>>(self, f: F) -> Self::Bind<B> {
 		self.and_then(f)
 	}
+
+	fn ret(val : A) -> Self {
+		return Ok(val);
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::ret;
 
 	#[test]
 	fn pure_test() {
-		let val: Result<i32, &'static str> = ret(42);
+		let val: Result<i32, &'static str> = Result::ret(42);
 		assert_eq!(val, Ok(42))
 	}
 
 	#[test]
 	fn binding() {
-		let val: Result<i32, &'static str> = ret(42);
-		let result = val.bind(|v| ret(v + 1));
+		let val: Result<i32, &'static str> = Result::ret(42);
+		let result = val.bind(|v| Result::ret(v + 1));
 		assert_eq!(result, Ok(43))
 	}
 
@@ -50,13 +33,13 @@ mod tests {
 	fn short_curcuit() {
 		fn meaning_of_life(v: i32) -> Result<i32, &'static str> {
 			if v == 42 {
-				ret(42)
+				Result::ret(42)
 			} else {
 				return Err("That answer is not the meaning of life");
 			}
 		}
 
-		let val: Result<i32, &'static str> = ret(43);
+		let val: Result<i32, &'static str> = Result::ret(43);
 		let result = val.bind(meaning_of_life);
 		assert!(result.is_err())
 	}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,19 @@
+use super::{Applicative, Functor, Monad};
+use std::{rc::Rc, marker::PhantomData};
+
+
+#[derive(Clone)]
+struct State<'a, S,V> {
+    runState: &'a (dyn Fn(S) -> V),
+}
+
+impl<'a,S:'a,A:'a> Functor<'a,A> for State<S,A> {
+	type Map<B> = State<S,B>;
+
+	fn map<B, F: Fn(A) -> B>(self, f: &'static F) -> Self::Map<B> {
+        let rs = self.runState.clone();
+        let new_rs = move |s| f(rs.as_ref()(s));
+        return Self::Map::<B>{runState : Rc::new(new_rs)}
+	}
+}
+

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use super::{Functor, Monad};
+use super::Monad;
 
 pub struct State<'a, S, V> {
 	run_state: Box<dyn Fn(S) -> (S, V) + 'a>,
@@ -18,23 +18,6 @@ impl<'a, S: Clone + 'a, V> State<'a, S, V> {
 		let f = move |_| (s.clone(), ());
 		State {
 			run_state: Box::new(f),
-		}
-	}
-}
-
-impl<'a, S: 'a, A: 'a> Functor<'a, A> for State<'a, S, A> {
-	type Target<B> = State<'a, S, B>;
-	fn fmap<B, F>(self, f: F) -> Self::Target<B>
-	where
-		F: Fn(A) -> B + 'a,
-	{
-		let new_f = move |s| {
-			let (new_state, new_value) = self.run_state.as_ref()(s);
-			(new_state, f(new_value))
-		};
-
-		State {
-			run_state: Box::new(new_f),
 		}
 	}
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,19 +1,62 @@
-use super::{Applicative, Functor, Monad};
-use std::{rc::Rc, marker::PhantomData};
-
+use super::{Functor, Monad};
+use std::rc::Rc;
 
 #[derive(Clone)]
-struct State<'a, S,V> {
-    runState: &'a (dyn Fn(S) -> V),
+pub struct State<'a, S, V> {
+	pub run_state: Rc<dyn Fn(S) -> (S, V) + 'a>,
 }
 
-impl<'a,S:'a,A:'a> Functor<'a,A> for State<S,A> {
-	type Map<B> = State<S,B>;
-
-	fn map<B, F: Fn(A) -> B>(self, f: &'static F) -> Self::Map<B> {
-        let rs = self.runState.clone();
-        let new_rs = move |s| f(rs.as_ref()(s));
-        return Self::Map::<B>{runState : Rc::new(new_rs)}
+impl<'a, S: Clone + 'a, V> State<'a, S, V> {
+	pub fn get() -> State<'a, S, S> {
+		let f = move |s: S| (s.clone(), s);
+		State {
+			run_state: Rc::new(f),
+		}
+	}
+	pub fn set(s: S) -> State<'a, S, ()> {
+		let f = move |_| (s.clone(), ());
+		State {
+			run_state: Rc::new(f),
+		}
 	}
 }
 
+impl<'a, S: 'a, A: 'a> Functor<'a, A> for State<'a, S, A> {
+	type Target<B> = State<'a, S, B>;
+	fn fmap<B, F>(self, f: F) -> Self::Target<B>
+	where
+		F: Fn(A) -> B + 'a,
+	{
+		let new_f = move |s| {
+			let (new_state, new_value) = self.run_state.as_ref()(s);
+			(new_state, f(new_value))
+		};
+
+		State {
+			run_state: Rc::new(new_f),
+		}
+	}
+}
+
+impl<'c, S: 'c, C: 'c + Clone> Monad<'c, C> for State<'c, S, C> {
+	type Bind<B> = State<'c, S, B>;
+
+	/// Sequentially compose two actions, passing any value produced by the
+	/// first as an argument to the second.
+	fn bind<B, F: Fn(C) -> Self::Bind<B> + 'c>(self, f: F) -> Self::Bind<B> {
+		let new_f = move |s| {
+			let (sp, vp) = self.run_state.as_ref()(s);
+			let m = f(vp);
+			return m.run_state.as_ref()(sp);
+		};
+		State {
+			run_state: Rc::new(new_f),
+		}
+	}
+	fn ret(c: C) -> Self {
+		let f = move |s| (s, c.clone());
+		State {
+			run_state: Rc::new(f),
+		}
+	}
+}


### PR DESCRIPTION
This PR reworks the lifetime constraints in the Monad interface, as well as drops the requirement for monads to implement functor and applicative.
This was necessary to get the State monad working with the rust lifetimes.

All of the other monad examples have been refactored to implement the new interface

The State monad has been added into the library and an example usage has been created; a simple tic tac toe game.